### PR TITLE
Fixes to use with WC

### DIFF
--- a/assets/js/sidebar-login.js
+++ b/assets/js/sidebar-login.js
@@ -6,23 +6,23 @@ jQuery(function(){
 		var $thisform = jQuery( this );
 		var action    = $thisform.attr('action');
 
-	    jQuery('.sidebar_login_error').remove();
+	    jQuery('.'+sidebar_login_params.error_class).remove();
 
 	    // Check required fields as a minimum
 	    var user_login = $thisform.find('input[name="log"]').val();
 	    var user_password = $thisform.find('input[name="pwd"]').val();
 
 	    if ( ! user_login ) {
-	    	$thisform.prepend('<p class="sidebar_login_error">' + sidebar_login_params.i18n_username_required + '</p>');
+	    	$thisform.prepend('<p class="' + sidebar_login_params.error_class + '">' + sidebar_login_params.i18n_username_required + '</p>');
 	    	return false;
 	    }
 	    if ( ! user_password ) {
-	    	$thisform.prepend('<p class="sidebar_login_error">' + sidebar_login_params.i18n_password_required + '</p>');
+			$thisform.prepend('<p class="' + sidebar_login_params.error_class + '">' + sidebar_login_params.i18n_password_required + '</p>');	    	
 	    	return false;
 	    }
 
 		// Check for SSL/FORCE SSL LOGIN
-		if ( action.indexOf( 'https:' ) >= 0 && sidebar_login_params.is_ssl == 0 )
+		if ( sidebar_login_params.force_ssl_login == 1 && sidebar_login_params.is_ssl == 0 )
 			return true;
 
 		$thisform.block({ message: null, overlayCSS: {
@@ -54,7 +54,7 @@ jQuery(function(){
 				if ( result.success == 1 ) {
 					window.location = result.redirect;
 				} else {
-					$thisform.prepend('<p class="sidebar_login_error">' + result.error + '</p>');
+					$thisform.prepend('<p class="' + sidebar_login_params.error_class + '">' + result.error + '</p>');	    						
 					$thisform.unblock();
 				}
 			}

--- a/sidebar-login.php
+++ b/sidebar-login.php
@@ -9,7 +9,7 @@ Author URI: http://mikejolley.com
 Requires at least: 3.5
 Tested up to: 3.5
 
-	Copyright: © 2013 Mike Jolley.
+	Copyright: ï¿½ 2013 Mike Jolley.
 	License: GNU General Public License v3.0
 	License URI: http://www.gnu.org/licenses/gpl-3.0.html
 */
@@ -56,13 +56,15 @@ class Sidebar_Login {
 	 */
 	public function enqueue() {
 
+		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+
 		$js_in_footer = apply_filters( 'sidebar_login_js_in_footer', false );
 
 		// Register BLOCK UI
 		wp_register_script( 'jquery-blockui', plugins_url( 'assets/js/blockui.min.js', __FILE__ ), array( 'jquery' ), '2.57', $js_in_footer );
 
 		// Enqueue Sidebar Login JS
-		wp_enqueue_script( 'sidebar-login', plugins_url( 'assets/js/sidebar-login.min.js', __FILE__ ), array( 'jquery', 'jquery-blockui' ), $this->version, $js_in_footer );
+		wp_enqueue_script( 'sidebar-login', plugins_url( 'assets/js/sidebar-login' . $suffix . '.js', __FILE__ ), array( 'jquery', 'jquery-blockui' ), $this->version, $js_in_footer );
 
 		// Enqueue Styles
 		if ( apply_filters( 'sidebar_login_include_css', true ) ) {
@@ -77,7 +79,8 @@ class Sidebar_Login {
 			'force_ssl_admin'  => force_ssl_admin() ? 1 : 0,
 			'is_ssl'           => is_ssl() ? 1 : 0,
 			'i18n_username_required' => __( 'Please enter your username', 'sidebar_login' ),
-			'i18n_password_required' => __( 'Please enter your password', 'sidebar_login' )
+			'i18n_password_required' => __( 'Please enter your password', 'sidebar_login' ),
+			'error_class'      => apply_filters( 'sidebar_login_widget_error_class', 'sidebar_login_error' )
 		);
 
 		wp_localize_script( 'sidebar-login', 'sidebar_login_params', $sidebar_login_params );


### PR DESCRIPTION
Addresses the following:

1) Introduces sidebar_login_widget_error_class filter which is used to style errors.
Defaults to sidebar_login_error, but can be filtered to use woocommerce-error

2) Honors SCRIPT_DEBUG define to select between .min.js and .js for debugging

3) Fixes SSL bug - 
I believe your check for FORCE_SSL_LOGIN to 'skip' Ajax is wrong. You should be checking force_ssl_login, not whether the URL is prefixed with https://
A site can set force_ssl_admin but not force_ssl_login, which is what I have done to get ajax on the login widget. 

4) My editor complained about your copyright symbol not being UTF8 and I think it changed it - so double check that.

5) I did not regen the .min.js
