### PR TITLE
Add a filter to be able to modify the Login HTML

### DIFF
--- a/includes/class-sidebar-login-widget.php
+++ b/includes/class-sidebar-login-widget.php
@@ -293,7 +293,7 @@ class Sidebar_Login_Widget extends WP_Widget {
 			$show_rememberme = ! isset( $this->instance['show_rememberme'] ) || ! empty( $this->instance['show_rememberme'] );
 
 			$login_form_args = apply_filters( 'sidebar_login_widget_form_args', array(
-		        'echo' 				=> true,
+		        'echo' 				=> false,
 		        'redirect' 			=> esc_url( apply_filters( 'sidebar_login_widget_login_redirect', $redirect ) ),
 		        'label_username' 	=> __( 'Username', 'sidebar-login' ),
 		        'label_password' 	=> __( 'Password', 'sidebar-login' ),
@@ -303,7 +303,9 @@ class Sidebar_Login_Widget extends WP_Widget {
 		        'value_remember' 	=> true
 		    ) );
 
-			wp_login_form( $login_form_args );
+			$html = wp_login_form( $login_form_args );
+			
+			echo apply_filters( 'sidebar_login_widget_logged_out_wp_login_form', $html);
 
 			$this->show_links( 'logged_out', $logged_out_links );
 

--- a/includes/class-sidebar-login-widget.php
+++ b/includes/class-sidebar-login-widget.php
@@ -305,7 +305,7 @@ class Sidebar_Login_Widget extends WP_Widget {
 
 			$html = wp_login_form( $login_form_args );
 			
-			echo apply_filters( 'sidebar_login_widget_logged_out_wp_login_form', $html);
+			echo apply_filters( 'sidebar_login_widget_logged_out_wp_login_form', $html, $login_form_args );
 
 			$this->show_links( 'logged_out', $logged_out_links );
 

--- a/readme.txt
+++ b/readme.txt
@@ -55,6 +55,7 @@ These tags can be used in the widget settings for titles + links and will be rep
 * `sidebar_login_widget_logout_redirect` - the redirect after logging out.
 * `sidebar_login_widget_register_url` - The URL for registration links.
 * `sidebar_login_widget_lost_password_url` - The URL for lost password links.
+* `sidebar_login_widget_logged_out_wp_login_form` - The HTML of the Login form.
 
 = Action Reference =
 


### PR DESCRIPTION
This pull requests simply adds a filter around the HTML that is generated by Wordpress. The problem is that wordpress only filters the arguments, but not the output of the function.

(What I really want to accomplish is adding the labels as placeholder, maybe I will write a core patch for this.)