### PR TITLE
Fix a typo resulting in a PHP warning

### DIFF
--- a/includes/class-sidebar-login-widget.php
+++ b/includes/class-sidebar-login-widget.php
@@ -210,7 +210,7 @@ class Sidebar_Login_Widget extends WP_Widget {
 
 		$links = apply_filters( 'sidebar_login_widget_' . $show . '_links', $links );
 
-		if ( ! empty( $links ) && is_array( $links ) && sizeof( $links > 0 ) ) {
+		if ( ! empty( $links ) && is_array( $links ) && sizeof( $links ) > 0 ) {
 			echo '<ul class="pagenav sidebar_login_links">';
 
 			foreach ( $links as $id => $link ) {


### PR DESCRIPTION
Because `sizeof` is mistakingly applied to a boolean, php shows a warning: PHP Warning:  sizeof(): Parameter must be an array or an object that implements Countable.
