### PR TITLE
Fix undefined index notices

### DIFF
--- a/src/Widget.php
+++ b/src/Widget.php
@@ -48,10 +48,7 @@ class Widget extends WP_Widget {
 			'logged_in_links'         => __( "Dashboard | %admin_url%\nProfile | %admin_url%/profile.php\nLogout | %logout_url%", 'sidebar-login' ),
 			'show_avatar'             => '1',
 		);
-		if ( empty( $instance ) ) {
-			$instance = $defaults;
-		}
-		return $instance;
+		return wp_parse_args( $instance, $defaults );
 	}
 
 	/**


### PR DESCRIPTION
When creating a new widget instance all fields contain a undefined index notice.
This fixes this issue because it makes sure the parameters always exist.